### PR TITLE
Allowing functionality on Windows (10)

### DIFF
--- a/smof.py
+++ b/smof.py
@@ -3616,7 +3616,10 @@ class Tail(Subcommand):
 
 
 if __name__ == "__main__":
-    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    if os.name is not 'nt':
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    if os.name is 'nt':
+        os.system('color')	#allows ANSI color on windows
     args = parse()
     gen = FSeqGenerator(args)
     args.func(args, gen, out=sys.stdout)

--- a/smof/main.py
+++ b/smof/main.py
@@ -3614,7 +3614,10 @@ class Tail(Subcommand):
 
 
 def main():
-    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    if os.name is not 'nt':
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    if os.name is 'nt':
+        os.system('color')	#allows ANSI color on windows
     args = parse()
     gen = FSeqGenerator(args)
     args.func(args, gen, out=sys.stdout)


### PR DESCRIPTION
1. SIGPIPE does not work on windows, doing OS check before running
2. Added line to allow ANSI color codes to display in windows CMD

Tested most commands, to confirm they work. Did not test pipes.